### PR TITLE
Add real estate projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# simulateur
+# Simulateur
+
+This project contains a few financial tools built with React and TypeScript.
+
+## Features
+
+- **Battre l'inflation** – compare your custom investment against the Livret A.
+- **Projet immobilier** – simulate a rental real estate investment and visualize cashflows and remaining loan over time.
+
+Use the navigation links in the header ("Battre l'inflation" and "Projet Immo") or the cards on the home page to access each tool.
+
+## Development
+
+Install dependencies and run the linter and type checks:
+
+```bash
+npm install
+npm run lint
+npm run build
+```
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Header from './components/Header';
 import Home from './components/Home';
 import InflationBeat from './components/InflationBeat';
+import RealEstateProjection from './components/RealEstateProjection';
 import Login from './components/Auth/Login';
 import Register from './components/Auth/Register';
 import { AuthProvider } from './contexts/AuthContext';
@@ -15,6 +16,8 @@ function App() {
         return <Home onNavigate={setCurrentPage} />;
       case 'inflation-beat':
         return <InflationBeat />;
+      case 'projet-immo':
+        return <RealEstateProjection />;
       case 'login':
         return <Login onNavigate={setCurrentPage} />;
       case 'register':

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,12 +41,22 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
             <button
               onClick={() => onNavigate('inflation-beat')}
               className={`text-sm font-medium transition-colors ${
-                currentPage === 'inflation-beat' 
-                  ? 'text-primary-600 border-b-2 border-primary-600 pb-1' 
+                currentPage === 'inflation-beat'
+                  ? 'text-primary-600 border-b-2 border-primary-600 pb-1'
                   : 'text-gray-500 hover:text-gray-700'
               }`}
             >
               Battre l'inflation
+            </button>
+            <button
+              onClick={() => onNavigate('projet-immo')}
+              className={`text-sm font-medium transition-colors ${
+                currentPage === 'projet-immo'
+                  ? 'text-primary-600 border-b-2 border-primary-600 pb-1'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              Projet Immo
             </button>
           </nav>
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TrendingUp, Calculator, Shield, Target } from 'lucide-react';
+import { TrendingUp, Calculator, Shield, Target, Home as HomeIcon } from 'lucide-react';
 
 interface HomeProps {
   onNavigate: (page: string) => void;
@@ -13,6 +13,13 @@ const Home: React.FC<HomeProps> = ({ onNavigate }) => {
       description: 'Comparez vos placements avec le Livret A et découvrez la meilleure stratégie pour préserver votre pouvoir d\'achat.',
       action: 'inflation-beat',
       buttonText: 'Calculer maintenant'
+    },
+    {
+      icon: HomeIcon,
+      title: 'Projet immobilier',
+      description: 'Simulez un investissement locatif et visualisez sa rentabilité.',
+      action: 'projet-immo',
+      buttonText: 'Lancer la simulation'
     },
     {
       icon: Shield,

--- a/src/components/RealEstateProjection.tsx
+++ b/src/components/RealEstateProjection.tsx
@@ -1,0 +1,302 @@
+import React, { useState } from 'react';
+import { Home as HomeIcon, BarChart } from 'lucide-react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import {
+  calculateNotaryFees,
+  calculateMonthlyPayment,
+  buildRealEstateProjection,
+  formatCurrency,
+} from '../utils/calculations';
+import { RealEstateYearData } from '../types';
+
+const RealEstateProjection: React.FC = () => {
+  const [price, setPrice] = useState(200000);
+  const [contribution, setContribution] = useState(20000);
+  const [duration, setDuration] = useState(20);
+  const [rate, setRate] = useState(2.5);
+  const [rent, setRent] = useState(1000);
+  const [charges, setCharges] = useState(100);
+  const [tax, setTax] = useState(1000);
+  const [insurance, setInsurance] = useState(20);
+  const [vacancy, setVacancy] = useState(0);
+  const [projection, setProjection] = useState<RealEstateYearData[]>([]);
+  const [showResults, setShowResults] = useState(false);
+
+  const handleCalculate = () => {
+    const data = buildRealEstateProjection({
+      price,
+      contribution,
+      duration,
+      rate,
+      rent,
+      charges,
+      tax,
+      insurance,
+      vacancyWeeks: vacancy,
+    });
+    setProjection(data);
+    setShowResults(true);
+  };
+
+  const notaryFees = calculateNotaryFees(price);
+  const loanAmount = price - contribution;
+  const monthlyPayment =
+    loanAmount > 0 ? calculateMonthlyPayment(loanAmount, rate, duration) : 0;
+
+  const monthlyCashflow =
+    rent * (1 - vacancy / 52) - charges - insurance - tax / 12 - monthlyPayment;
+
+  const grossYield = (rent * 12 * 100) / price;
+  const netAnnualIncome =
+    (rent * (1 - vacancy / 52) - charges - insurance) * 12 - tax;
+  const netYield = (netAnnualIncome * 100) / price;
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-4 border rounded-lg shadow-lg">
+          <p className="font-semibold mb-2">{`Année ${label}`}</p>
+          {payload.map((entry: any, index: number) => (
+            <p key={index} className="text-sm" style={{ color: entry.color }}>
+              {`${entry.name}: ${formatCurrency(entry.value)}`}
+            </p>
+          ))}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8">
+        <div className="text-center">
+          <div className="flex items-center justify-center mb-4">
+            <HomeIcon className="h-12 w-12 text-primary-600" />
+          </div>
+          <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            Projet immobilier
+          </h1>
+          <p className="text-lg text-gray-600">
+            Simulez un investissement locatif et visualisez sa rentabilité.
+          </p>
+        </div>
+
+        <div className="grid lg:grid-cols-2 gap-8">
+          <div className="bg-white p-8 rounded-xl shadow-lg space-y-6">
+            <h2 className="text-2xl font-semibold text-gray-900 flex items-center">
+              <BarChart className="h-6 w-6 mr-2 text-primary-600" />
+              Paramètres
+            </h2>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Prix du bien
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={price}
+                    onChange={(e) => setPrice(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">€</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Apport personnel
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={contribution}
+                    onChange={(e) => setContribution(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">€</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Durée du prêt
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={duration}
+                    onChange={(e) => setDuration(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">ans</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Taux du prêt
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={rate}
+                    onChange={(e) => setRate(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                    step="0.1"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">%</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Loyer mensuel attendu
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={rent}
+                    onChange={(e) => setRent(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">€</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Charges mensuelles
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={charges}
+                    onChange={(e) => setCharges(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">€</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Taxe foncière annuelle
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={tax}
+                    onChange={(e) => setTax(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">€</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Assurance mensuelle
+                </label>
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={insurance}
+                    onChange={(e) => setInsurance(Number(e.target.value))}
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  />
+                  <span className="absolute right-3 top-2 text-gray-500">€</span>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Vacance (semaines/an)
+                </label>
+                <input
+                  type="range"
+                  min="0"
+                  max="8"
+                  value={vacancy}
+                  onChange={(e) => setVacancy(Number(e.target.value))}
+                  className="w-full"
+                />
+                <p className="text-sm text-gray-500 mt-1">{vacancy} semaines</p>
+              </div>
+              <button
+                onClick={handleCalculate}
+                className="w-full bg-primary-600 text-white py-3 rounded-lg hover:bg-primary-700"
+              >
+                Calculer
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            {showResults ? (
+              <>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="bg-white p-6 rounded-xl shadow-lg">
+                    <h3 className="text-sm font-medium text-gray-500 mb-2">
+                      Mensualité
+                    </h3>
+                    <p className="text-2xl font-bold text-primary-600">
+                      {formatCurrency(monthlyPayment)}
+                    </p>
+                  </div>
+                  <div className="bg-white p-6 rounded-xl shadow-lg">
+                    <h3 className="text-sm font-medium text-gray-500 mb-2">
+                      Cashflow mensuel
+                    </h3>
+                    <p className="text-2xl font-bold text-emerald-600">
+                      {formatCurrency(monthlyCashflow)}
+                    </p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="bg-white p-6 rounded-xl shadow-lg text-center">
+                    <p className="text-sm text-gray-500">Rendement brut</p>
+                    <p className="text-xl font-semibold">{grossYield.toFixed(2)}%</p>
+                  </div>
+                  <div className="bg-white p-6 rounded-xl shadow-lg text-center">
+                    <p className="text-sm text-gray-500">Rendement net</p>
+                    <p className="text-xl font-semibold">{netYield.toFixed(2)}%</p>
+                  </div>
+                </div>
+                <div className="bg-white p-6 rounded-xl shadow-lg">
+                  <div className="h-96">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={projection} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                        <XAxis dataKey="year" tick={{ fontSize: 12 }} label={{ value: 'Années', position: 'insideBottom', offset: -10 }} />
+                        <YAxis tick={{ fontSize: 12 }} tickFormatter={(v) => `${(v / 1000).toFixed(0)}k€`} />
+                        <Tooltip content={<CustomTooltip />} />
+                        <Legend />
+                        <Line type="monotone" dataKey="remainingPrincipal" stroke="#3b82f6" name="Capital restant dû" strokeWidth={3} />
+                        <Line type="monotone" dataKey="cumulativeCashflow" stroke="#10b981" name="Cashflow cumulé" strokeWidth={3} />
+                        <Line type="monotone" dataKey="totalProfit" stroke="#f59e0b" name="Profit total" strokeWidth={3} />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="bg-white p-12 rounded-xl shadow-lg text-center">
+                <HomeIcon className="h-16 w-16 text-gray-300 mx-auto mb-4" />
+                <p className="text-gray-500">Remplissez le formulaire pour voir la projection</p>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="text-sm text-gray-500">
+          Frais de notaire estimés : {formatCurrency(notaryFees)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RealEstateProjection;
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,3 +26,22 @@ export interface CalculationParams {
   inflationRate: number;
   monthlyContribution?: number;
 }
+
+export interface RealEstateProjectionInput {
+  price: number;
+  contribution: number;
+  duration: number;
+  rate: number;
+  rent: number;
+  charges: number;
+  tax: number;
+  insurance: number;
+  vacancyWeeks: number;
+}
+
+export interface RealEstateYearData {
+  year: number;
+  remainingPrincipal: number;
+  cumulativeCashflow: number;
+  totalProfit: number;
+}


### PR DESCRIPTION
## Summary
- add a real estate projection simulator with chart
- implement calculations helpers for real estate
- extend shared types with projection interfaces
- integrate new page in navigation and home features
- document new feature

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6e32b7708326986daa65bb33b682