### PR TITLE
Fix notary fee calculation

### DIFF
--- a/src/components/RealEstateProjection.tsx
+++ b/src/components/RealEstateProjection.tsx
@@ -36,7 +36,9 @@ const RealEstateProjection: React.FC = () => {
   const [vacancy, setVacancy] = useState(0);
   const [propertyGrowthRate, setPropertyGrowthRate] = useState(0);
   const [sellYear, setSellYear] = useState(duration);
-  const [notaryFees, setNotaryFees] = useState(calculateNotaryFees(price));
+  const [notaryFees, setNotaryFees] = useState(
+    Math.round(calculateNotaryFees(price))
+  );
   const [projection, setProjection] = useState<RealEstateYearData[]>([]);
   const [showResults, setShowResults] = useState(false);
 
@@ -166,6 +168,7 @@ const RealEstateProjection: React.FC = () => {
                     value={notaryFees}
                     onChange={(e) => setNotaryFees(Number(e.target.value))}
                     className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                    step={1}
                   />
                   <span className="absolute right-3 top-2 text-gray-500">€</span>
                 </div>

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -75,7 +75,8 @@ export const formatCurrency = (amount: number): string => {
 export const getLivretARate = (): number => LIVRET_A_RATE;
 
 // --- Real estate helpers ---
-export const calculateNotaryFees = (price: number): number => price * 0.07;
+export const calculateNotaryFees = (price: number): number =>
+  Math.round(price * 0.07);
 
 export const calculateMonthlyPayment = (
   loanAmount: number,


### PR DESCRIPTION
## Summary
- round the result of `calculateNotaryFees`
- round the initial notary fee state value
- restrict notary fee input to whole euros

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d873273fc8326a70d60ce06cde7e8