### PR TITLE
Add repaid principal tracking

### DIFF
--- a/src/components/RealEstateProjection.tsx
+++ b/src/components/RealEstateProjection.tsx
@@ -454,7 +454,7 @@ const RealEstateProjection: React.FC = () => {
                         <YAxis tick={{ fontSize: 12 }} tickFormatter={(v) => `${(v / 1000).toFixed(0)}k€`} />
                         <Tooltip content={<CustomTooltip />} />
                         <Legend />
-                        <Line type="monotone" dataKey="remainingPrincipal" stroke="#3b82f6" name="Capital restant dû" strokeWidth={3} />
+                        <Line type="monotone" dataKey="repaidPrincipal" stroke="#3b82f6" name="Capital remboursé" strokeWidth={3} />
                         <Line type="monotone" dataKey="cumulativeCashflow" stroke="#10b981" name="Cashflow cumulé" strokeWidth={3} />
                         <Line type="monotone" dataKey="enrichissement" stroke="#f59e0b" name="Enrichissement" strokeWidth={3} />
                       </LineChart>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,7 @@ export interface RealEstateProjectionInput {
 export interface RealEstateYearData {
   year: number;
   remainingPrincipal: number;
+  repaidPrincipal: number;
   cumulativeCashflow: number;
   enrichissement: number;
   propertyValue: number;

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -162,6 +162,7 @@ export const buildRealEstateProjection = (
       results.push({
         year,
         remainingPrincipal: Math.max(0, Math.round(remaining)),
+        repaidPrincipal: Math.round(capitalRepaid),
         cumulativeCashflow: Math.round(cumulativeCashflow),
         enrichissement: Math.round(enrichissement),
         propertyValue: Math.round(propertyValue),


### PR DESCRIPTION
## Summary
- extend `RealEstateYearData` with `repaidPrincipal`
- include repaid capital in `buildRealEstateProjection`
- plot the repaid principal in the projection chart

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d873c0ec48326aca451be3e68a99f