### PR TITLE
Synchronize livret A rate and update projections

### DIFF
--- a/src/components/ComparisonChart.tsx
+++ b/src/components/ComparisonChart.tsx
@@ -6,9 +6,14 @@ import { formatCurrency } from '../utils/calculations';
 interface ComparisonChartProps {
   data: InvestmentComparison[];
   customRate: number;
+  livretARate: number;
 }
 
-const ComparisonChart: React.FC<ComparisonChartProps> = ({ data, customRate }) => {
+const ComparisonChart: React.FC<ComparisonChartProps> = ({
+  data,
+  customRate,
+  livretARate,
+}) => {
   const CustomTooltip = ({ active, payload, label }: any) => {
     if (active && payload && payload.length) {
       return (
@@ -54,7 +59,7 @@ const ComparisonChart: React.FC<ComparisonChartProps> = ({ data, customRate }) =
               dataKey="livretA"
               stroke="#f59e0b"
               strokeWidth={3}
-              name="Livret A (3%)"
+              name={`Livret A (${livretARate}%)`}
               dot={{ fill: '#f59e0b', strokeWidth: 2, r: 4 }}
               activeDot={{ r: 6, stroke: '#f59e0b', strokeWidth: 2 }}
             />
@@ -84,7 +89,7 @@ const ComparisonChart: React.FC<ComparisonChartProps> = ({ data, customRate }) =
         <div className="text-center p-4 bg-amber-50 rounded-lg">
           <div className="w-4 h-4 bg-amber-500 mx-auto mb-2 rounded"></div>
           <p className="text-sm font-medium text-amber-800">Livret A</p>
-          <p className="text-xs text-amber-600">Taux garanti 3%</p>
+          <p className="text-xs text-amber-600">Taux garanti {livretARate}%</p>
         </div>
         <div className="text-center p-4 bg-emerald-50 rounded-lg">
           <div className="w-4 h-4 bg-emerald-500 mx-auto mb-2 rounded"></div>

--- a/src/components/InflationBeat.tsx
+++ b/src/components/InflationBeat.tsx
@@ -263,7 +263,11 @@ const InflationBeat: React.FC = () => {
                 </div>
 
                 {/* Chart */}
-                <ComparisonChart data={comparisonData} customRate={customRate} />
+                <ComparisonChart
+                  data={comparisonData}
+                  customRate={customRate}
+                  livretARate={livretARate}
+                />
               </>
             )}
 

--- a/src/components/RealEstateProjection.tsx
+++ b/src/components/RealEstateProjection.tsx
@@ -194,32 +194,6 @@ const RealEstateProjection: React.FC = () => {
               <BarChart className="h-6 w-6 mr-2 text-primary-600" />
               Paramètres
             </h2>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="bg-white p-6 rounded-xl shadow-lg">
-                <h3 className="text-sm font-medium text-gray-500 mb-2">Mensualité</h3>
-                <p className="text-2xl font-bold text-primary-600">
-                  {formatCurrency(monthlyPayment)}
-                </p>
-              </div>
-              <div className="bg-white p-6 rounded-xl shadow-lg">
-                <h3 className="text-sm font-medium text-gray-500 mb-2">Cashflow mensuel</h3>
-                <p className="text-2xl font-bold text-emerald-600">
-                  {formatCurrency(monthlyCashflow)}
-                </p>
-              </div>
-              <div className="bg-white p-6 rounded-xl shadow-lg text-center">
-                <p className="text-sm text-gray-500">Rendement brut</p>
-                <p className="text-xl font-semibold">{grossYield.toFixed(2)}%</p>
-              </div>
-              <div className="bg-white p-6 rounded-xl shadow-lg text-center">
-                <p className="text-sm text-gray-500">Rendement net</p>
-                <p className={`text-xl font-semibold ${netYieldColor}`}>{netYield.toFixed(2)}%</p>
-              </div>
-              <div className="bg-white p-6 rounded-xl shadow-lg text-center">
-                <p className="text-sm text-gray-500">Décision</p>
-                <p className={`text-xl font-semibold ${netYieldColor}`}>{decision}</p>
-              </div>
-            </div>
             <div className="grid grid-cols-3 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -537,6 +511,10 @@ const RealEstateProjection: React.FC = () => {
           </div>
 
           <div className="space-y-6">
+            <h2 className="text-2xl font-semibold text-gray-900 flex items-center">
+              <BarChart className="h-6 w-6 mr-2 text-primary-600" />
+              Projection
+            </h2>
             <div className="grid grid-cols-2 gap-4">
               <div className="bg-white p-6 rounded-xl shadow-lg">
                 <h3 className="text-sm font-medium text-gray-500 mb-2">Budget global</h3>
@@ -599,6 +577,12 @@ const RealEstateProjection: React.FC = () => {
                     </ResponsiveContainer>
                   </div>
                 </div>
+                <button
+                  onClick={() => window.print()}
+                  className="w-full bg-primary-600 text-white py-3 rounded-lg hover:bg-primary-700"
+                >
+                  Enregistrer en PDF
+                </button>
               </>
             ) : (
               <div className="bg-white p-12 rounded-xl shadow-lg text-center">


### PR DESCRIPTION
## Summary
- make Livret A rate configurable in `ComparisonChart`
- remove duplicate calculated cards from real-estate parameters
- show a **Projection** title on the results side
- add a button to save the real-estate projection as PDF

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b2700fe2883269e6230ba1e417ac3