### PR TITLE
feat: add city autocomplete in real estate projection

### DIFF
--- a/src/utils/fetchCities.ts
+++ b/src/utils/fetchCities.ts
@@ -1,0 +1,24 @@
+export interface CitySuggestion {
+  nom: string;
+  code: string;
+  codePostal: string;
+}
+
+export async function fetchCities(query: string): Promise<CitySuggestion[]> {
+  const params = new URLSearchParams({ limit: '5', boost: 'population', fields: 'nom,code,codesPostaux' });
+  const isPostalCode = /^\d+$/.test(query);
+  if (isPostalCode) {
+    params.set('codePostal', query);
+  } else {
+    params.set('nom', query);
+  }
+  const res = await fetch(`https://geo.api.gouv.fr/communes?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error('Network response was not ok');
+  }
+  const data = await res.json();
+  // data is array of communes, each with nom, code, codesPostaux (array)
+  return data.flatMap((commune: { nom: string; code: string; codesPostaux: string[] }) =>
+    commune.codesPostaux.map((cp: string) => ({ nom: commune.nom, code: commune.code, codePostal: cp }))
+  );
+}


### PR DESCRIPTION
## Summary
- add geo.api.gouv.fr city search utility
- integrate city autocomplete with postal code suggestions in real estate projection form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/RealEstateProjection.tsx src/utils/fetchCities.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899eec72cd88326b1940bbeabc61f28