### PR TITLE
Add DVF-based average price per m² lookup

### DIFF
--- a/src/components/RealEstateProjection.tsx
+++ b/src/components/RealEstateProjection.tsx
@@ -125,12 +125,26 @@ const RealEstateProjection: React.FC = () => {
   };
 
   const handleCityBlur = async () => {
-    const cityName = selectedCity ? selectedCity.nom : city.replace(/^\d+\s+/, '');
-    if (!cityName) return;
+    const inputCity = city.replace(/^\d+\s+/, '');
+    let cityCode = selectedCity?.code;
+    if (!cityCode && inputCity) {
+      try {
+        const results = await fetchCities(inputCity);
+        if (results.length > 0) {
+          cityCode = results[0].code;
+        }
+      } catch {
+        // ignore lookup errors
+      }
+    }
+    if (!cityCode) {
+      setCityError('Ville introuvable.');
+      return;
+    }
     try {
       setCityError(null);
       setAverageCityPrice(null);
-      const pricePerSqm = await fetchCityPrice(cityName);
+      const pricePerSqm = await fetchCityPrice(cityCode);
       setAverageCityPrice(pricePerSqm);
     } catch {
       setCityError('Erreur lors de la récupération du prix de la ville.');

--- a/src/utils/fetchCityPrice.ts
+++ b/src/utils/fetchCityPrice.ts
@@ -1,13 +1,66 @@
-export interface CityPriceResponse {
-  averagePrice: number;
+interface DVFRecord {
+  fields: {
+    date_mutation?: string;
+    type_local?: string;
+    surface_reelle_bati?: number;
+    valeur_fonciere?: number;
+  };
 }
 
-export async function fetchCityPrice(city: string): Promise<number> {
-  const url = `https://api.example.com/prices?city=${encodeURIComponent(city)}`;
+export async function fetchCityPrice(cityCode: string): Promise<number> {
+  const params = new URLSearchParams();
+  params.set('dataset', 'demandes-de-valeurs-foncieres');
+  params.set('rows', '10000');
+  params.set('refine.code_commune', cityCode);
+  params.set('refine.nature_mutation', 'Vente');
+
+  const url = `https://data.economie.gouv.fr/api/records/1.0/search/?${params.toString()}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error('Network response was not ok');
   }
-  const data: CityPriceResponse = await res.json();
-  return data.averagePrice;
+  const data = await res.json();
+  const now = new Date();
+  const twoYearsAgo = new Date();
+  twoYearsAgo.setMonth(now.getMonth() - 24);
+
+  const prices: number[] = ((data.records as DVFRecord[]) || [])
+    .map((record) => record.fields)
+    .filter((f) => {
+      const date = f.date_mutation ? new Date(f.date_mutation) : null;
+      return (
+        date &&
+        date >= twoYearsAgo &&
+        date <= now &&
+        (f.type_local === 'Appartement' || f.type_local === 'Maison') &&
+        typeof f.surface_reelle_bati === 'number' &&
+        f.surface_reelle_bati >= 10 &&
+        f.surface_reelle_bati <= 300 &&
+        typeof f.valeur_fonciere === 'number'
+      );
+    })
+    .map(
+      (f) => (f.valeur_fonciere as number) / (f.surface_reelle_bati as number),
+    );
+
+  if (prices.length === 0) {
+    throw new Error('No transactions found');
+  }
+
+  prices.sort((a, b) => a - b);
+  const lower = Math.floor(prices.length * 0.05);
+  const upper = Math.ceil(prices.length * 0.95) - 1;
+  const trimmed = prices.slice(lower, upper + 1);
+
+  if (trimmed.length === 0) {
+    throw new Error('No data after trimming');
+  }
+
+  const mid = Math.floor(trimmed.length / 2);
+  const median =
+    trimmed.length % 2 !== 0
+      ? trimmed[mid]
+      : (trimmed[mid - 1] + trimmed[mid]) / 2;
+
+  return median;
 }


### PR DESCRIPTION
## Summary
- fetch median price per square meter from DVF API
- look up city code before querying DVF and display suggested price

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: various existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f25a4c148326a6effc346ec1ca59