### PR TITLE
Improve DVF price fetch pagination and error feedback

### DIFF
--- a/src/components/RealEstateProjection.tsx
+++ b/src/components/RealEstateProjection.tsx
@@ -146,8 +146,12 @@ const RealEstateProjection: React.FC = () => {
       setAverageCityPrice(null);
       const pricePerSqm = await fetchCityPrice(cityCode);
       setAverageCityPrice(pricePerSqm);
-    } catch {
-      setCityError('Erreur lors de la récupération du prix de la ville.');
+    } catch (err) {
+      setCityError(
+        err instanceof Error
+          ? err.message
+          : 'Erreur lors de la récupération du prix de la ville.',
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- Paginate DVF API calls in `fetchCityPrice` with 1000-row batches and explicit status error handling
- Surface detailed city price fetch errors in `RealEstateProjection` so users can see the cause of failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899fa0410508326928141ed1533aa62