### PR TITLE
fix: correct dataset slug and add explicit 404 message

### DIFF
--- a/src/utils/fetchCityPrice.ts
+++ b/src/utils/fetchCityPrice.ts
@@ -9,7 +9,7 @@ interface DVFRecord {
 
 export async function fetchCityPrice(cityCode: string): Promise<number> {
   const params = new URLSearchParams();
-  params.set('dataset', 'demandes-de-valeurs-foncieres');
+  params.set('dataset', 'dvf_demandes-de-valeurs-foncieres');
   // API maximum allowed rows is 1000 per request
   params.set('rows', '1000');
   params.set('refine.code_commune', cityCode);
@@ -21,6 +21,11 @@ export async function fetchCityPrice(cityCode: string): Promise<number> {
     params.set('start', start.toString());
     const url = `https://data.economie.gouv.fr/api/records/1.0/search/?${params.toString()}`;
     const res = await fetch(url);
+    if (res.status === 404) {
+      throw new Error(
+        'DVF dataset not found. Please verify the dataset slug is correct.',
+      );
+    }
     if (!res.ok) {
       throw new Error(`DVF API ${res.status} ${res.statusText}`);
     }


### PR DESCRIPTION
## Summary
- use the new `dvf_demandes-de-valeurs-foncieres` dataset slug
- add explicit error message when DVF API returns 404

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / unused-vars)*
- `node -e fetch('https://data.economie.gouv.fr/api/records/1.0/search/?dataset=dvf_demandes-de-valeurs-foncieres&rows=1')` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689a06de63948326a0c431e3a2305fd6