### PR TITLE
fix: correct DVF dataset slug

### DIFF
--- a/src/utils/fetchCityPrice.ts
+++ b/src/utils/fetchCityPrice.ts
@@ -9,7 +9,7 @@ interface DVFRecord {
 
 export async function fetchCityPrice(cityCode: string): Promise<number> {
   const params = new URLSearchParams();
-  params.set('dataset', 'dvf_demandes-de-valeurs-foncieres');
+  params.set('dataset', 'dvf_dvf');
   // API maximum allowed rows is 1000 per request
   params.set('rows', '1000');
   params.set('refine.code_commune', cityCode);


### PR DESCRIPTION
## Summary
- point DVF API to the proper `dvf_dvf` dataset so city lookups succeed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/utils/fetchCityPrice.ts`


------
https://chatgpt.com/codex/tasks/task_e_689afcf082f0832691c8f4243c67f001