### PR TITLE
Add login requirement backed by server-side auth

### DIFF
--- a/server/sql/001_init.sql
+++ b/server/sql/001_init.sql
@@ -9,3 +9,10 @@ CREATE TABLE IF NOT EXISTS dvf_raw (
 
 CREATE INDEX IF NOT EXISTS idx_dvf_raw_commune_date ON dvf_raw(code_commune, date_mutation);
 CREATE INDEX IF NOT EXISTS idx_dvf_raw_type ON dvf_raw(type_local);
+
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  first_name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL
+);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,13 +2,16 @@ import express from 'express';
 import cors from 'cors';
 import communes from './routes/communes';
 import prix from './routes/prix';
+import auth from './routes/auth';
 import { PORT } from './config';
 
 const app = express();
 app.use(cors());
+app.use(express.json());
 
 app.use('/api/communes', communes);
 app.use('/api/prix-m2', prix);
+app.use('/api/auth', auth);
 
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import crypto from 'crypto';
+import { pool } from '../db/pool';
+
+const router = Router();
+
+router.post('/register', async (req, res) => {
+  const schema = z.object({
+    firstName: z.string().min(1),
+    email: z.string().email(),
+    password: z.string().min(6),
+  });
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Paramètres invalides' });
+  }
+  const { firstName, email, password } = parsed.data;
+  const client = await pool.connect();
+  try {
+    const existing = await client.query('SELECT id FROM users WHERE email = $1', [email]);
+    if (existing.rowCount > 0) {
+      return res.status(409).json({ error: 'Email déjà utilisé' });
+    }
+    const salt = crypto.randomBytes(16).toString('hex');
+    const hash = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+    const combined = `${salt}:${hash}`;
+    const result = await client.query(
+      'INSERT INTO users(first_name, email, password_hash) VALUES ($1, $2, $3) RETURNING id, first_name, email',
+      [firstName, email, combined],
+    );
+    const user = result.rows[0];
+    res.json({ id: user.id, firstName: user.first_name, email: user.email });
+  } finally {
+    client.release();
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const schema = z.object({
+    email: z.string().email(),
+    password: z.string().min(1),
+  });
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Paramètres invalides' });
+  }
+  const { email, password } = parsed.data;
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      'SELECT id, first_name, email, password_hash FROM users WHERE email = $1',
+      [email],
+    );
+    if (result.rowCount === 0) {
+      return res.status(401).json({ error: 'Identifiants invalides' });
+    }
+    const user = result.rows[0];
+    const [salt, storedHash] = user.password_hash.split(':');
+    const hash = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+    if (hash !== storedHash) {
+      return res.status(401).json({ error: 'Identifiants invalides' });
+    }
+    res.json({ id: user.id, firstName: user.first_name, email: user.email });
+  } finally {
+    client.release();
+  }
+});
+
+export default router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,37 +5,42 @@ import InflationBeat from './components/InflationBeat';
 import RealEstateProjection from './components/RealEstateProjection';
 import Login from './components/Auth/Login';
 import Register from './components/Auth/Register';
-import { AuthProvider } from './contexts/AuthContext';
+import { useAuth } from './contexts/AuthContext';
 
 function App() {
   const [currentPage, setCurrentPage] = useState('home');
+  const { isAuthenticated } = useAuth();
+
+  const handleNavigate = (page: string) => {
+    if (!isAuthenticated && (page === 'inflation-beat' || page === 'projet-immo')) {
+      setCurrentPage('login');
+    } else {
+      setCurrentPage(page);
+    }
+  };
 
   const renderPage = () => {
     switch (currentPage) {
       case 'home':
-        return <Home onNavigate={setCurrentPage} />;
+        return <Home onNavigate={handleNavigate} />;
       case 'inflation-beat':
         return <InflationBeat />;
       case 'projet-immo':
         return <RealEstateProjection />;
       case 'login':
-        return <Login onNavigate={setCurrentPage} />;
+        return <Login onNavigate={handleNavigate} />;
       case 'register':
-        return <Register onNavigate={setCurrentPage} />;
+        return <Register onNavigate={handleNavigate} />;
       default:
-        return <Home onNavigate={setCurrentPage} />;
+        return <Home onNavigate={handleNavigate} />;
     }
   };
 
   return (
-    <AuthProvider>
-      <div className="min-h-screen bg-gray-50 font-inter">
-        <Header currentPage={currentPage} onNavigate={setCurrentPage} />
-        <main>
-          {renderPage()}
-        </main>
-      </div>
-    </AuthProvider>
+    <div className="min-h-screen bg-gray-50 font-inter">
+      <Header currentPage={currentPage} onNavigate={handleNavigate} />
+      <main>{renderPage()}</main>
+    </div>
   );
 }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, AuthContextType } from '../types';
 
+const API_BASE = 'http://localhost:3001/api';
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 interface AuthProviderProps {
@@ -20,30 +21,21 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const register = async (firstName: string, email: string, password: string): Promise<boolean> => {
     try {
-      // Simulate registration process
-      const existingUsers = JSON.parse(localStorage.getItem('focusPatrimoineUsers') || '[]');
-      
-      // Check if user already exists
-      if (existingUsers.find((u: any) => u.email === email)) {
+      const res = await fetch(`${API_BASE}/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ firstName, email, password }),
+      });
+      if (res.ok) {
+        const newUser: User = await res.json();
+        setUser(newUser);
+        localStorage.setItem('focusPatrimoineUser', JSON.stringify(newUser));
+        return true;
+      }
+      if (res.status === 409) {
         return false;
       }
-
-      const newUser: User = {
-        id: Date.now().toString(),
-        firstName,
-        email,
-      };
-
-      // Save user credentials (in real app, this would be handled by backend)
-      const userWithPassword = { ...newUser, password };
-      existingUsers.push(userWithPassword);
-      localStorage.setItem('focusPatrimoineUsers', JSON.stringify(existingUsers));
-      
-      // Set current user
-      setUser(newUser);
-      localStorage.setItem('focusPatrimoineUser', JSON.stringify(newUser));
-      
-      return true;
+      return false;
     } catch (error) {
       console.error('Registration error:', error);
       return false;
@@ -52,20 +44,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = async (email: string, password: string): Promise<boolean> => {
     try {
-      const existingUsers = JSON.parse(localStorage.getItem('focusPatrimoineUsers') || '[]');
-      const foundUser = existingUsers.find((u: any) => u.email === email && u.password === password);
-      
-      if (foundUser) {
-        const user: User = {
-          id: foundUser.id,
-          firstName: foundUser.firstName,
-          email: foundUser.email,
-        };
+      const res = await fetch(`${API_BASE}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (res.ok) {
+        const user: User = await res.json();
         setUser(user);
         localStorage.setItem('focusPatrimoineUser', JSON.stringify(user));
         return true;
       }
-      
       return false;
     } catch (error) {
       console.error('Login error:', error);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { AuthProvider } from './contexts/AuthContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add users table and API routes for registration and login
- guard navigation so tools require authentication

## Testing
- `npm run lint` *(fails: 16 problems, 14 errors)*
- `npm run build`
- `cd server && npm run lint` *(fails: 8 problems)*
- `cd server && npm test` *(fails: function nullif(float,integer) does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689b024e7f64832684b08931ec002ec5