### PR TITLE
Fix missing try block in register function

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -34,6 +34,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const newUser: User = await res.json();
         setUser(newUser);
         localStorage.setItem('focusPatrimoineUser', JSON.stringify(newUser));
+        return { ok: true };
+      }
+
+      const { error } = await res.json().catch(() => ({ error: "Une erreur est survenue lors de l'inscription" }));
+      return { ok: false, error };
     } catch (error) {
       console.error('Registration error:', error);
       return { ok: false, error: "Une erreur est survenue lors de l'inscription" };


### PR DESCRIPTION
## Summary
- handle registration errors by properly closing try/catch and returning `RegisterResult`

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f8061d0c8326a0cf81de05ff6870