### PR TITLE
Improve auth error handling

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -31,6 +31,9 @@ router.post('/register', async (req, res) => {
     );
     const user = result.rows[0];
     res.json({ id: user.id, firstName: user.first_name, email: user.email });
+  } catch (err) {
+    console.error('Registration error:', err);
+    return res.status(500).json({ error: "Erreur lors de l'inscription" });
   } finally {
     client.release();
   }
@@ -62,6 +65,9 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ error: 'Identifiants invalides' });
     }
     res.json({ id: user.id, firstName: user.first_name, email: user.email });
+  } catch (err) {
+    console.error('Login error:', err);
+    return res.status(500).json({ error: 'Erreur lors de la connexion' });
   } finally {
     client.release();
   }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -37,11 +37,23 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         return { ok: true };
       }
 
-      const { error } = await res.json().catch(() => ({ error: "Une erreur est survenue lors de l'inscription" }));
-      return { ok: false, error };
+      let errorMessage = "Une erreur est survenue lors de l'inscription";
+      try {
+        const data = await res.json();
+        if (data?.error) {
+          errorMessage = data.error;
+        } else if (res.status >= 500) {
+          errorMessage = 'Erreur serveur. Veuillez réessayer plus tard.';
+        }
+      } catch {
+        errorMessage = res.status >= 500
+          ? 'Erreur serveur. Veuillez réessayer plus tard.'
+          : 'Réponse inattendue du serveur';
+      }
+      return { ok: false, error: errorMessage };
     } catch (error) {
       console.error('Registration error:', error);
-      return { ok: false, error: "Une erreur est survenue lors de l'inscription" };
+      return { ok: false, error: 'Impossible de contacter le serveur. Veuillez réessayer plus tard.' };
     }
   };
 


### PR DESCRIPTION
## Summary
- Add detailed error handling for user registration on client to surface server and network issues
- Return JSON error responses on server-side auth routes

## Testing
- `npm test` (fails: ERROR: function nullif(float,integer) does not exist)
- `npm run lint` (fails: 14 problems)

------
https://chatgpt.com/codex/tasks/task_e_68a6fc4585c88326a8a04c5d7ea8867f