### PR TITLE
feat: configure api base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ npm run lint
 npm run build
 ```
 
+### Environment
+
+The frontend expects an API endpoint to handle authentication and other
+requests. Configure the API base URL via the `VITE_API_BASE` environment
+variable when starting the development server:
+
+```bash
+VITE_API_BASE=http://localhost:3001/api npm run dev
+```
+
+If `VITE_API_BASE` is not provided, the application defaults to `/api`, which
+assumes that the backend is served from the same origin as the frontend.
+

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,10 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { User, AuthContextType, RegisterResult } from '../types';
 
-const API_BASE = 'http://localhost:3001/api';
+// Allow configuring the API server through an environment variable so the
+// frontend can run against remote backends. Fall back to a relative path which
+// works when the API is served from the same origin.
+const API_BASE = import.meta.env.VITE_API_BASE || '/api';
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 interface AuthProviderProps {


### PR DESCRIPTION
## Summary
- allow setting API server via `VITE_API_BASE` and default to `/api`
- document API base URL configuration

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7079d47308326bc1989f585bcab51